### PR TITLE
Pkg 4786 update 2.21.5 cuda12.4

### DIFF
--- a/recipe/0002-use-conda-ar-not-system.patch
+++ b/recipe/0002-use-conda-ar-not-system.patch
@@ -1,0 +1,16 @@
+This fixes an issue where the build fails on linux-aarch64, because a system ar
+can't be found. Presumably it's using the system ar on other platforms, too,
+which isn't ideal.
+Index: nccl/src/Makefile
+===================================================================
+--- nccl.orig/src/Makefile	2024-05-16 16:58:16.522514975 -0500
++++ nccl/src/Makefile	2024-05-16 17:47:45.959416166 -0500
+@@ -83,7 +83,7 @@
+ $(LIBDIR)/$(STATICLIBTARGET): $(LIBOBJ) $(DEVMANIFEST)
+ 	@printf "Archiving  %-35s > %s\n" $(STATICLIBTARGET) $@
+ 	mkdir -p $(LIBDIR)
+-	ar cr $@ $(LIBOBJ) $$(cat $(DEVMANIFEST))
++	$(AR) cr $@ $(LIBOBJ) $$(cat $(DEVMANIFEST))
+ 
+ $(PKGDIR)/nccl.pc : nccl.pc.in
+ 	mkdir -p $(PKGDIR)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,7 @@ EXTRA_ARGS="CUDARTLIB=\"cudart_static\""
 
 if [[ "${cuda_compiler_version}" =~ 12.* ]]; then
   EXTRA_ARGS="${EXTRA_ARGS} CUDA_HOME=\"${PREFIX}\" NVCC=\"${BUILD_PREFIX}/bin/nvcc\""
+  export CUDA_HOME=${BUILD_PREFIX}
 elif [[ "${cuda_compiler_version}" != "None" ]]; then
   EXTRA_ARGS="${EXTRA_ARGS} CUDA_HOME=\"${CUDA_PATH}\""
 fi
@@ -19,8 +20,8 @@ if [[ $CONDA_BUILD_CROSS_COMPILATION == "1" ]]; then
     fi
 fi
 
-# `eval` is needed here for proper `${...}` expansion
-eval make -j${CPU_COUNT} src.lib ${EXTRA_ARGS}
+# Handing CUDA_HOME to make via an environment variable works; using eval and make args doesn't.
+make -j${CPU_COUNT} src.lib
 
 make install PREFIX="${PREFIX}"
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,10 +6,11 @@
 #   - 7.3               # [linux]
 # cxx_compiler_version: # [linux]
 #   - 7.3               # [linux]
-cuda_compiler: nvcc
+cuda_compiler: cuda-nvcc
 cuda_compiler_version:
-  - 9.2
+  #- 9.2
   #- 10.0
   # - 10.1
   #- 10.2
   #- 11.0
+  - 12.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   patches:
     # This isn't needed; setting CUDA_HOME sets NVCC correctly
     #- 0001-Allow-custom-NVCC-path.patch
+    - 0002-use-conda-ar-not-system.patch
 
 build:
   number: 0
@@ -28,6 +29,7 @@ requirements:
     - {{ compiler("cxx") }}
     - {{ compiler("cuda") }}
     - make
+    - patch
   host:
     - cuda-version ={{ cuda_compiler_version }}          # [(cuda_compiler_version or "").startswith("11")]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None", "10.2")]
+  skip: true  # [(not linux) or s390x or cuda_compiler_version in (undefined, "None", "10.2")]
   ignore_run_exports_from:
     # Ignore `cudatoolkit` dependency in CUDA 11 builds
     - {{ compiler("cuda") }}  # [(cuda_compiler_version or "").startswith("11")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,8 @@ source:
   url: https://github.com/NVIDIA/nccl/archive/v{{ version }}.tar.gz
   sha256: 1923596984d85e310b5b6c52b2c72a1b93da57218f2bc5a5c7ac3d59297a3303
   patches:
-    # Upstreaming w/PR: https://github.com/NVIDIA/nccl/pull/854
-    - 0001-Allow-custom-NVCC-path.patch
+    # This isn't needed; setting CUDA_HOME sets NVCC correctly
+    #- 0001-Allow-custom-NVCC-path.patch
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4786](https://anaconda.atlassian.net/browse/PKG-4786)

### Explanation of changes:

- Part of CUDA 12.4 build, following [conda-forge's pattern](https://github.com/conda-forge/staged-recipes/issues/21382) which was developed in conjunction with Nvidia. I don't see a need to stage these then release them all at once. They won't cause a problem released one at a time.
- Updated to 2.21.5 at the same time
- Please check the main branch too, this was synced with conda-forge using the github GUI to pull to master rather than in a PR. (is this ok? not ok? could be discussed.)
- Changes made to adjust feedstock for differences between conda-forge and defaults. Please see commit messages for description of changes.


[PKG-4786]: https://anaconda.atlassian.net/browse/PKG-4786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ