### PR TITLE
nccl v2.28.9.1 b1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,7 +6,6 @@
 #   - 7.3               # [linux]
 # cxx_compiler_version: # [linux]
 #   - 7.3               # [linux]
-cuda_compiler: cuda-nvcc
 cuda_compiler_version:
   #- 9.2
   #- 10.0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,16 +1,23 @@
-# # cuda 8.0, gcc 5.4, cudnn 7.1
-# # cuda 9.0, gcc 5.4, cudnn 7.3
-# # cuda 9.2, gcc 7.3, cudnn 7.3
-# # cuda 10.0, gcc 7.3, cudnn 7.3
-# c_compiler_version:   # [linux]
-#   - 7.3               # [linux]
-# cxx_compiler_version: # [linux]
-#   - 7.3               # [linux]
+# nccl supports CUDA enhanced compatibility, but CUDA 12.4 won't support GCC >= 13
+# So, keep CUDA 12.4 for GCC 11.2.0+ compatibility
+# Use latest CUDA 12.x and 13.x for GCC 14.3.0+ compatibility
 cuda_compiler_version:
-  #- 9.2
-  #- 10.0
-  # - 10.1
-  #- 10.2
-  #- 11.0
-  #- 12.4
+  - 12.4
   - 12.8
+  - 13.0
+
+c_compiler_version:
+  - 11.2.0
+  - 14.3.0
+  - 14.3.0
+
+cxx_compiler_version:
+  - 11.2.0
+  - 14.3.0
+  - 14.3.0
+
+zip_keys:
+  -
+    - c_compiler_version
+    - cxx_compiler_version
+    - cuda_compiler_version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 1
-  skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None")]
+  skip: true  # [not linux]
   ignore_run_exports:
     # ignore `cuda-version` constraint in CUDA 12+ as this supports CUDA Enhanced Compatibility.
     - cuda-version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-use-conda-ar-not-system.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None")]
   ignore_run_exports:
     # ignore `cuda-version` constraint in CUDA 12+ as this supports CUDA Enhanced Compatibility.
@@ -31,10 +31,9 @@ requirements:
     - {{ compiler("cuda") }}
     - make
   host:
-    - cuda-version ={{ cuda_compiler_version }}
+    - cuda-version {{ cuda_compiler_version }}
   run:
-    - {{ pin_compatible("cuda-version", lower_bound="12.2a0") }}                    # [(cuda_compiler_version or "").startswith("12")]
-    - {{ pin_compatible("cuda-version", min_pin="x", max_pin="x") }}                # [(cuda_compiler_version or "").startswith("13")]
+    - {{ pin_compatible("cuda-version", min_pin="x", max_pin="x") }}
 
 test:
   commands:


### PR DESCRIPTION
nccl 2.28.9.1 b1

**Destination channel:** defaults

### Links

- [PKG-10627](https://anaconda.atlassian.net/browse/PKG-10627) 
- [Upstream repository](https://github.com/NVIDIA/nccl)
- [Upstream changelog/diff](https://github.com/NVIDIA/nccl/releases/tag/v2.28.9-1)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cuda-feedstock/pull/3

### Explanation of changes:

- Sync recipe with CF
- Add CUDA 12.4 and 13.0 builds (with proper C/C++ compiler versions)
- Bump build number


[PKG-10627]: https://anaconda.atlassian.net/browse/PKG-10627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ