### PR TITLE
nccl v2.25.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,25 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
     fi
 fi
 
+# Why NVCC_APPEND_FLAGS?
+#
+#  NVCC resolves conflicting flags by using the last value. We use NVCC_APPEND_FLAGS
+#  to ensure our flags come after those set in NCCL's Makefile.
+#
+# Added flags:
+#
+#  -std=c++17: GCC 14's libstdc++ headers use C++17 inline variables and built-in traits
+#    that NVCC's EDG frontend cannot parse unless host compilation is also C++17.
+#    NCCL's Makefile hardcodes -std=c++11, so addition of this flag produces a harmless warning:
+#    "nvcc warning : incompatible redefinition for option 'std', the last value of this option was used"
+#    Reference: https://github.com/NVIDIA/nccl/blob/v2.25.1-1/makefiles/common.mk
+#
+#  -Wno-deprecated-gpu-targets: Suppress warnings about deprecated GPU targets
+#    (sm_50, sm_52, etc.) included in NVCC_GENCODE for broad compatibility.
+export NVCC_APPEND_FLAGS="${NVCC_APPEND_FLAGS} -std=c++17 -Wno-deprecated-gpu-targets"
+
+# Additional flags to make command:
+#  -j${CPU_COUNT}: Build with the number of CPUs specified by the CPU_COUNT environment variable.
 make -j${CPU_COUNT} src.lib
 
 make install PREFIX="${PREFIX}"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# NCCL v2.25.1-1 officially supports up to CUDA 12.8, but it compiles with CUDA 12.9 without any issues.#
+# Reference: https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-25-1.html#rel_2-25-1
+# Since "cuda-version" pin expands to ">=12,<13.0a0", we use CUDA 12.9 only for the build.
+cuda_compiler_version:
+  - "12.9"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,10 +14,14 @@ source:
 build:
   number: 0
   skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None", "12.6")]
-  ignore_run_exports_from:
-    # Ignore `cudatoolkit` dependency in CUDA 11 builds as it is unneeded.
-    # Also ignore `cuda-version` constraint in CUDA 12+ as this supports CUDA Enhanced Compatibility.
-    - {{ compiler("cuda") }}
+  ignore_run_exports:
+    # Using this section in recipes is usually not recommended, but necessary due to
+    # CUDA Compatibility support. That means, this package can support a version pin
+    # like "cuda-version >=12,<13.0a0".
+    # Reference: https://docs.nvidia.com/deploy/cuda-compatibility/
+    # Basically, adding "cuda-version" to this section will remove "cuda-version >=12.9,<13.0a0"
+    # from the runtime dependencies, and leave "cuda-version >=12,<13.0a0" only.
+    - cuda-version
   run_exports:
     # xref: https://github.com/NVIDIA/nccl/issues/218
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -46,14 +50,12 @@ about:
   license_family: BSD
   license_file: LICENSE.txt
   summary: Optimized primitives for collective multi-GPU communication
-
   description: |
     The NVIDIA Collective Communications Library (NCCL) implements multi-GPU
     and multi-node collective communication primitives that are performance
     optimized for NVIDIA GPUs. NCCL provides routines such as all-gather,
     all-reduce, broadcast, reduce, reduce-scatter, that are optimized to
     achieve high bandwidth over PCIe and NVLink high-speed interconnect.
-
   doc_url: https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/index.html
   dev_url: https://github.com/NVIDIA/nccl
 


### PR DESCRIPTION
nccl 2.25.1.1

**Destination channel:** defaults

### Links

- [PKG-11470](https://anaconda.atlassian.net/browse/PKG-11470) 
- [Upstream repository](https://github.com/NVIDIA/nccl/tree/v2.25.1-1)
- [Upstream changelog/diff](https://github.com/NVIDIA/nccl/releases/tag/v2.25.1-1)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- This is a release for older version of NCCL built against CUDA 12.x
- Based on conda-forge/nccl-feedstock@4e1c4fedb06d91499434751c0c04900c08530cc8 commit
- Added `NVCC_APPEND_FLAGS` to override hard-coded `-std=c++11` in the upstream vendor `Makefile` to `-std=c++17`. Added some comments to `build.sh` on why this is necessary.
- NCCL 2.25.1-1 is tested against up to CUDA 12.8 as per the release notes, but it compiles without any errors with CUDA 12.9
- Replaced `ignored_run_exports_from` with `ignore_run_exports` to synchronize with the latest version of `nccl-feedstock`. However, they both should have the same effect on the outcome. We can revert it back if requested, no problems.


[PKG-11470]: https://anaconda.atlassian.net/browse/PKG-11470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ