### PR TITLE
nccl 2.29.3-1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,23 +1,5 @@
-# nccl supports CUDA enhanced compatibility, but CUDA 12.4 won't support GCC >= 13
-# So, keep CUDA 12.4 for GCC 11.2.0+ compatibility
-# Use latest CUDA 12.x and 13.x for GCC 14.3.0+ compatibility
+# Latest versions of NCCL officially supports CUDA 12.x and 13.x
+# Reference: https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-29-3.html#rel_2-29-3
 cuda_compiler_version:
-  - 12.4
-  - 12.8
-  - 13.0
-
-c_compiler_version:
-  - 11.2.0
-  - 14.3.0
-  - 14.3.0
-
-cxx_compiler_version:
-  - 11.2.0
-  - 14.3.0
-  - 14.3.0
-
-zip_keys:
-  -
-    - c_compiler_version
-    - cxx_compiler_version
-    - cuda_compiler_version
+  - "12.9"
+  - "13.1"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,13 +12,16 @@ source:
     - 0001-use-conda-ar-not-system.patch
 
 build:
-  number: 1
+  number: 0
   skip: true  # [not linux]
   ignore_run_exports:
-    # ignore `cuda-version` constraint in CUDA 12+ as this supports CUDA Enhanced Compatibility.
+    # Using this section in recipes is usually not recommended, but necessary due to
+    # CUDA Compatibility support. That means, this package can support a version pin
+    # like "cuda-version >=12,<13.0a0".
+    # Reference: https://docs.nvidia.com/deploy/cuda-compatibility/
+    # Basically, adding "cuda-version" to this section will remove "cuda-version >=12.9,<13.0a0"
+    # from the runtime dependencies, and leave "cuda-version >=12,<13.0a0" only.
     - cuda-version
-  ignore_run_exports_from:
-    - {{ compiler("cuda") }}
   run_exports:
     # xref: https://github.com/NVIDIA/nccl/issues/218
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -47,14 +50,12 @@ about:
   license_family: BSD
   license_file: LICENSE.txt
   summary: Optimized primitives for collective multi-GPU communication
-
   description: |
     The NVIDIA Collective Communications Library (NCCL) implements multi-GPU
     and multi-node collective communication primitives that are performance
     optimized for NVIDIA GPUs. NCCL provides routines such as all-gather,
     all-reduce, broadcast, reduce, reduce-scatter, that are optimized to
     achieve high bandwidth over PCIe and NVLink high-speed interconnect.
-
   doc_url: https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/index.html
   dev_url: https://github.com/NVIDIA/nccl
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nccl" %}
-{% set version = "2.28.9-1" %}
+{% set version = "2.29.3-1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/NVIDIA/nccl/archive/v{{ version }}.tar.gz
-  sha256: f349860336c6b7fb97b22bed9c729142f3531a0e82826c1204d01e44af8b9cb9
+  sha256: d1dffc5e9dd059985704f98ff3d8b7e6cf62d20c10a181d427a4e3233f8148f1
   patches:
     - 0001-use-conda-ar-not-system.patch
 


### PR DESCRIPTION
nccl 2.29.3-1

**Destination channel:** defaults

### Links

- [PKG-12982](https://anaconda.atlassian.net/browse/PKG-12982) 
- [Upstream repository](https://github.com/NVIDIA/nccl/tree/v2.29.3-1)
- [Upstream changelog/diff](https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-29-3.html#rel_2-29-3)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Bump version and update hash
- Minor recipe cleanup


[PKG-12982]: https://anaconda.atlassian.net/browse/PKG-12982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ