### PR TITLE
nccl 2.29.7-1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+# Set PBP timeout to 16 hrs
+task_timeout: 57600

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+set -ex
+
+[[ ${target_platform} == "linux-64" ]] && targetsDir="targets/x86_64-linux"
+[[ ${target_platform} == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"
+# https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html?highlight=tegra#cross-compilation
+[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "sbsa" ]] && targetsDir="targets/sbsa-linux"
+[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "tegra" ]] && targetsDir="targets/aarch64-linux"
+
+if [ -z "${targetsDir+x}" ]; then
+    echo "target_platform: ${target_platform} is unknown! targetsDir must be defined!" >&2
+    exit 1
+fi
+
 if [[ -z "${CUDA_HOME+x}" ]]; then
   # `$CUDA_HOME` was set for CUDA 11.x and earlier.
   # Must be using CUDA 12.0+. So set to `$BUILD_PREFIX`.
@@ -9,7 +22,11 @@ fi
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
     if [[ "${target_platform}" == "linux-aarch64" ]]; then
-        export CUDA_LIB="${CUDA_HOME}/targets/sbsa-linux/lib/"
+        if [[ "${arm_variant_type}" == "tegra" ]]; then
+            export CUDA_LIB="${CUDA_HOME}/targets/aarch64-linux/lib/"
+        else
+            export CUDA_LIB="${CUDA_HOME}/targets/sbsa-linux/lib/"
+        fi
     elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
         export CUDA_LIB="${CUDA_HOME}/targets/ppc64le-linux/lib/"
     else
@@ -18,8 +35,41 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
     fi
 fi
 
-# Handing CUDA_HOME to make via an environment variable works; using eval and make args doesn't.
-make -j${CPU_COUNT} src.lib
+# For now, we emit LLVM IR for CUDA 12.x only.
+if [[ "${cuda_compiler_version}" == 12.* ]]; then
+    EMIT_LLVM_IR=1
+else
+    EMIT_LLVM_IR=0
+fi
+
+# NCCL's Makefile assumes a standard system-wide CUDA installation where
+# everything lives under one directory (e.g. /usr/local/cuda/include,
+# /usr/local/cuda/bin/nvcc, etc.). Conda does not install CUDA that way.
+# Instead, CUDA is split across many small packages and headers live under
+# platform-specific target directories like:
+#   $BUILD_PREFIX/targets/x86_64-linux/include/
+#   $BUILD_PREFIX/targets/sbsa-linux/include/
+#
+# We override NCCL Makefile's CUDA_HOME, CUDA_INC, NVCC
+# to point at the actual conda paths. None of this would be needed if CUDA
+# were installed the standard way.
+
+# CUDA_INC: tells nvcc/gcc where to find CUDA headers (cuda.h, etc.)
+# when compiling libnccl.so. Must point to the target platform's headers.
+CUDA_INC="$BUILD_PREFIX/$targetsDir/include"
+
+# Also there is another issue with clang at https://github.com/llvm/llvm-project/blob/dfcbf6c70e7088e4b10e9c9c47bdfa19eb031228/clang/lib/Headers/__clang_cuda_runtime_wrapper.h#L483-L493
+# Maybe clang should have #if __has_include("curand_mtgp32_kernel.h") so it will not
+# unconditionally include the header.
+# NCCL does not need this header so just touch the file so clang can find it.
+# Listing libcurand-dev as a host dependency won't help because clang needs it in the
+# build env. Listing it as a build: dependency breaks cross-compilation for linux-aarch64
+touch "$BUILD_PREFIX/$targetsDir/include/curand_mtgp32_kernel.h"
+
+make -j1 pkg.txz.build EMIT_LLVM_IR="$EMIT_LLVM_IR" \
+  CUDA_HOME="$BUILD_PREFIX" \
+  CUDA_INC="$CUDA_INC" \
+  NVCC="$BUILD_PREFIX/bin/nvcc"
 
 make install PREFIX="${PREFIX}"
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,8 @@
+arm_variant_type:  # [linux and aarch64]
+  - sbsa           # [linux and aarch64]
+
 # Latest versions of NCCL officially supports CUDA 12.x and 13.x
 # Reference: https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-29-3.html#rel_2-29-3
 cuda_compiler_version:
-  - "12.9"
-  - "13.1"
+  - 12.9
+  - 13.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - {{ compiler("cxx") }}
     - {{ compiler("cuda") }}
     - arm-variant * {{ arm_variant_type }}  # [linux and aarch64]
+    - clang 21.*  # [(cuda_compiler_version or "").startswith("12")]
     - llvm-tools  # [(cuda_compiler_version or "").startswith("12")]
     - make
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nccl" %}
-{% set version = "2.29.3-1" %}
+{% set version = "2.29.7-1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/NVIDIA/nccl/archive/v{{ version }}.tar.gz
-  sha256: d1dffc5e9dd059985704f98ff3d8b7e6cf62d20c10a181d427a4e3233f8148f1
+  sha256: e67239212c395bfdb398a7519491840d06fdf6b599c299f97c7ed0109777bba1
   patches:
     - 0001-use-conda-ar-not-system.patch
 
@@ -32,6 +32,8 @@ requirements:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - {{ compiler("cuda") }}
+    - arm-variant * {{ arm_variant_type }}  # [linux and aarch64]
+    - llvm-tools
     - make
   host:
     - cuda-version {{ cuda_compiler_version }}
@@ -41,7 +43,9 @@ requirements:
 test:
   commands:
     - test -f "${PREFIX}/include/nccl.h"
+    - test -f "${PREFIX}/include/nccl_device_wrapper.h"  # [(cuda_compiler_version or "").startswith("12")]
     - test -f "${PREFIX}/lib/libnccl.so"
+    - test -f "${PREFIX}/lib/libnccl_device.bc"          # [(cuda_compiler_version or "").startswith("12")]
     - test ! -f "${PREFIX}/lib/libnccl_static.a"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - {{ compiler("cxx") }}
     - {{ compiler("cuda") }}
     - arm-variant * {{ arm_variant_type }}  # [linux and aarch64]
-    - llvm-tools
+    - llvm-tools  # [(cuda_compiler_version or "").startswith("12")]
     - make
   host:
     - cuda-version {{ cuda_compiler_version }}


### PR DESCRIPTION
nccl 2.29.7-1

**Destination channel:** defaults

### Links

- [PKG-13629](https://anaconda.atlassian.net/browse/PKG-13629) 
- [Upstream repository](https://github.com/NVIDIA/nccl/tree/v2.29.7-1)
- [Upstream changelog/diff](https://github.com/NVIDIA/nccl/releases/tag/v2.29.7-1)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Synchronize with the upstream feedstock (build scripts)
- Upstream feedstock is building `libnccl_device.bc` using `clang` and `llvm-tools` for CUDA 12.9 only (see `EMIT_LLVM_IR`  on `build.sh`). It looks like they have used `-j1` intentionally to prevent intermittent compilation errors.
- `clang` version pin comes from the commit history, see `HEAD` of the upstream feedstock repository to see the `clang` version pin for CUDA 12.9
- Added `arm_variant_type` block to `cbc.yaml`

### Notes

- The latest version will be released separately on a different Jira ticket.


[PKG-13629]: https://anaconda.atlassian.net/browse/PKG-13629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ