### PR TITLE
nccl v2.30.4-1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -35,13 +35,6 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
     fi
 fi
 
-# For now, we emit LLVM IR for CUDA 12.x only.
-if [[ "${cuda_compiler_version}" == 12.* ]]; then
-    EMIT_LLVM_IR=1
-else
-    EMIT_LLVM_IR=0
-fi
-
 # NCCL's Makefile assumes a standard system-wide CUDA installation where
 # everything lives under one directory (e.g. /usr/local/cuda/include,
 # /usr/local/cuda/bin/nvcc, etc.). Conda does not install CUDA that way.
@@ -66,7 +59,8 @@ CUDA_INC="$BUILD_PREFIX/$targetsDir/include"
 # build env. Listing it as a build: dependency breaks cross-compilation for linux-aarch64
 touch "$BUILD_PREFIX/$targetsDir/include/curand_mtgp32_kernel.h"
 
-make -j1 pkg.txz.build EMIT_LLVM_IR="$EMIT_LLVM_IR" \
+# https://github.com/conda-forge/nccl-feedstock/issues/159
+make -j$CPU_COUNT pkg.txz.build EMIT_LLVM_IR=1 \
   CUDA_HOME="$BUILD_PREFIX" \
   CUDA_INC="$CUDA_INC" \
   NVCC="$BUILD_PREFIX/bin/nvcc"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,8 @@ requirements:
     - {{ compiler("cuda") }}
     - arm-variant * {{ arm_variant_type }}  # [linux and aarch64]
     - clang 21.*  # [(cuda_compiler_version or "").startswith("12")]
-    - llvm-tools  # [(cuda_compiler_version or "").startswith("12")]
+    - clang 22.*  # [(cuda_compiler_version or "").startswith("13")]
+    - llvm-tools
     - make
   host:
     - cuda-version {{ cuda_compiler_version }}
@@ -44,9 +45,9 @@ requirements:
 test:
   commands:
     - test -f "${PREFIX}/include/nccl.h"
-    - test -f "${PREFIX}/include/nccl_device_wrapper.h"  # [(cuda_compiler_version or "").startswith("12")]
+    - test -f "${PREFIX}/include/nccl_device_wrapper.h"
     - test -f "${PREFIX}/lib/libnccl.so"
-    - test -f "${PREFIX}/lib/libnccl_device.bc"          # [(cuda_compiler_version or "").startswith("12")]
+    - test -f "${PREFIX}/lib/libnccl_device.bc"
     - test ! -f "${PREFIX}/lib/libnccl_static.a"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nccl" %}
-{% set version = "2.29.7-1" %}
+{% set version = "2.30.4-1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/NVIDIA/nccl/archive/v{{ version }}.tar.gz
-  sha256: e67239212c395bfdb398a7519491840d06fdf6b599c299f97c7ed0109777bba1
+  sha256: fe12cb244a4aea4c802d0a18d1072e10f102fc39c2530a8251c2abdaeea9ecba
   patches:
     - 0001-use-conda-ar-not-system.patch
 


### PR DESCRIPTION
nccl 2.30.4-1

**Destination channel:** defaults

### Links

- [PKG-13805](https://anaconda.atlassian.net/browse/PKG-13771) 
- [Upstream repository](https://github.com/NVIDIA/nccl/tree/v2.30.4-1)
- [Upstream changelog/diff](https://github.com/NVIDIA/nccl/releases/tag/v2.30.4-1)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Bump version and update hash
- Enable `libnccl_device.bc` builds for CUDA 13.x
- Update dependencies
- Update build script
- Add `make -j$CPU_COUNT ...` to `build.sh`; see: https://github.com/conda-forge/nccl-feedstock/issues/159


[PKG-13805]: https://anaconda.atlassian.net/browse/PKG-13805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ